### PR TITLE
new: Add MISP export

### DIFF
--- a/src/model.py
+++ b/src/model.py
@@ -1,10 +1,10 @@
 from typing import List, Optional
-from Cryptodome.PublicKey import RSA
+from Cryptodome.PublicKey import RSA  # type: ignore
 from urllib.parse import urlparse
-from malduck import base64, rsa
+from malduck import base64, rsa  # type: ignore
 import re
 from enum import Enum
-from pymisp import MISPObject
+from pymisp import MISPObject  # type: ignore
 
 
 def is_ipv4(possible_ip: str):
@@ -163,7 +163,7 @@ class IocCollection:
     def add_network_location(self, netloc: NetworkLocation) -> None:
         self.network_locations.append(netloc)
 
-    def to_misp(self) -> [MISPObject]:
+    def to_misp(self) -> List[MISPObject]:
         """MISP JSON output"""
         to_return = []
         for rsa_key in self.rsa_keys:


### PR DESCRIPTION
Note: Requires PyMISP from the development branch.

It's a work in progress and I'll play with it more in the coming days, but that's an example.

```python

from mwdblib import Malwarecage
from mwdb_iocextract import parse

from pymisp import ExpandedPyMISP, MISPEvent
from keys import misp_url, misp_key, misp_verifycert

mwdb_api = '<key>'

mwdb = Malwarecage(api_key=mwdb_api)

config = mwdb.query('938d1b4ce29ccb6c4f36c5110a57455670d0b8b2611a50f69e1a438ad73dcf97')


misp_objects = parse(config.family, config.config)

event = MISPEvent()
event.add_tag(f'mwdb:family:{config.family}')
event.info = f'Configuration {config.sha256}'

event.add_attribute('link', f'https://mwdb.cert.pl/config/{config.sha256}')

for o in misp_objects.to_misp():
    event.add_object(o)

misp = ExpandedPyMISP(misp_url, misp_key, misp_verifycert)
misp.add_event(event)


```