### PR TITLE
Remove Config import from mwdb scanning example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ recent configs we utilise the
 bindings for [mwdb](mwdb.cert.pl)]).
 
 ```python
-from mwdb_iocextract import parse, Config
+from mwdb_iocextract import parse
 from mwdblib import Malwarecage
 
 


### PR DESCRIPTION
**Description**  
As far as I can see, `Config` is not available as part of the mwdb_iocextract project. I tried to revert to old commits and couldn't find `Config` there as well. Anyways, it causes exception in the example so this PR removes it.

If it is necessary to have `Config` there, please let me know

**Test Case**
1. Execute the example script on a fresh installation and see the exception when trying to import 
`Config`.
2. Fetch this PR and see that it fixes the error.