### PR TITLE
Fix small python issue in upload_to_misp example on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ iocs.emails  # emails used by malware
 You can convert `IocCollection` to a MISP object:
 
 ```python
-def upload_to_misp(family, config)
+def upload_to_misp(family, config):
     try:
         iocs = parse(family, config)
     except FamilyNotSupportedYetError:


### PR DESCRIPTION
**Description**
Just a tiny little fix for a missing `:` in the function definition